### PR TITLE
Adjust status badges URIs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 This module adds support for the OpenID Connect protocol through a SimpleSAMLphp module installable through Composer.
 
-[![Build Status](https://travis-ci.org/rediris-es/simplesamlphp-module-oidc.svg?branch=master)](https://travis-ci.org/rediris-es/simplesamlphp-module-oidc) 
-[![Coverage Status](https://coveralls.io/repos/github/rediris-es/simplesamlphp-module-oidc/badge.svg?branch=master)](https://coveralls.io/github/rediris-es/simplesamlphp-module-oidc?branch=master)
-[![SimpleSAMLphp](https://img.shields.io/badge/simplesamlphp-1.18-red.svg)](https://simplesamlphp.org/)
+[![Build Status](https://github.com/simplesamlphp/simplesamlphp-module-oidc/actions/workflows/test.yaml/badge.svg)](https://github.com/simplesamlphp/simplesamlphp-module-oidc/actions/workflows/test.yaml) 
+[![Coverage Status](https://codecov.io/gh/simplesamlphp/simplesamlphp-module-oidc/branch/master/graph/badge.svg)](https://app.codecov.io/gh/simplesamlphp/simplesamlphp-module-oidc)
+[![SimpleSAMLphp](https://img.shields.io/badge/simplesamlphp-1.19-brightgreen)](https://simplesamlphp.org/)
 
 ![Main screen capture](docs/oidc.png)
 


### PR DESCRIPTION
* Travis was moved to GitHub Actions
* Coveralls was moved to CodeCov
* SSP badge was modified so that is shows version 1.19

Fixes #142 