### PR TITLE
Allow overriding cert+key name/location

### DIFF
--- a/config-templates/module_oidc.php
+++ b/config-templates/module_oidc.php
@@ -18,6 +18,9 @@ $config = [
 
     // The private key passphrase (optional)
     // 'pass_phrase' => 'secret',
+    // The cert and key for signing the ID token. Default names are oidc_module.pem and oidc_module.crt
+    // 'privatekey' => 'oidc_module.pem',
+    // 'certificate' => 'oidc_module.crt',
 
     // Tokens TTL
     'authCodeDuration' => 'PT10M', // 10 minutes

--- a/lib/Services/ConfigurationService.php
+++ b/lib/Services/ConfigurationService.php
@@ -192,7 +192,8 @@ class ConfigurationService
      */
     public function getCertPath(): string
     {
-        return Config::getCertPath('oidc_module.crt');
+        $certName = $this->getOpenIDConnectConfiguration()->getString('certificate', 'oidc_module.crt');
+        return Config::getCertPath($certName);
     }
 
     /**
@@ -201,7 +202,8 @@ class ConfigurationService
      */
     public function getPrivateKeyPath(): string
     {
-        return Config::getCertPath('oidc_module.pem');
+        $keyName = $this->getOpenIDConnectConfiguration()->getString('privatekey', 'oidc_module.pem');
+        return Config::getCertPath($keyName);
     }
 
     /**

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -131,7 +131,7 @@ class Container implements ContainerInterface
         $formFactory = new FormFactory($configurationService);
         $this->services[FormFactory::class] = $formFactory;
 
-        $jsonWebKeySetService = new JsonWebKeySetService();
+        $jsonWebKeySetService = new JsonWebKeySetService($configurationService);
         $this->services[JsonWebKeySetService::class] = $jsonWebKeySetService;
 
         $session = Session::getSessionFromRequest();

--- a/lib/Services/JsonWebKeySetService.php
+++ b/lib/Services/JsonWebKeySetService.php
@@ -27,9 +27,13 @@ class JsonWebKeySetService
      */
     private $jwkSet;
 
-    public function __construct()
+    /**
+     * @param ConfigurationService $configurationService
+     * @throws Exception
+     */
+    public function __construct(ConfigurationService $configurationService)
     {
-        $publicKeyPath = Config::getCertPath('oidc_module.crt');
+        $publicKeyPath = $configurationService->getCertPath();
 
         if (!file_exists($publicKeyPath)) {
             throw new Exception("OpenId Connect certification file does not exists: {$publicKeyPath}.");

--- a/tests/Services/ConfigurationServiceTest.php
+++ b/tests/Services/ConfigurationServiceTest.php
@@ -2,13 +2,44 @@
 
 namespace SimpleSAML\Test\Module\oidc\Services;
 
+use SimpleSAML\Configuration;
 use SimpleSAML\Module\oidc\Services\ConfigurationService;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationServiceTest extends TestCase
 {
-    public function testIncomplete(): void
+    public function testSigningKeyNameCanBeCustomized(): void
     {
-        $this->markTestIncomplete();
+        $certDir = '/tmp/cert/';
+        Configuration::clearInternalState();
+        Configuration::setPreLoadedConfig(
+            Configuration::loadFromArray(
+                [
+                    'certdir' => $certDir
+                ]
+            )
+        );
+        Configuration::setPreLoadedConfig(
+            Configuration::loadFromArray([]),
+            'module_oidc.php'
+        );
+        // Test default cert and pem
+        $service = new ConfigurationService();
+        $this->assertEquals($certDir . 'oidc_module.crt', $service->getCertPath());
+        $this->assertEquals($certDir . 'oidc_module.pem', $service->getPrivateKeyPath());
+
+        // Set customized
+        Configuration::setPreLoadedConfig(
+            Configuration::loadFromArray(
+                [
+                    'privatekey' => 'myPrivateKey.key',
+                    'certificate' => 'myCertificate.pem',
+                ]
+            ),
+            'module_oidc.php'
+        );
+        $service = new ConfigurationService();
+        $this->assertEquals($certDir . 'myCertificate.pem', $service->getCertPath());
+        $this->assertEquals($certDir . 'myPrivateKey.key', $service->getPrivateKeyPath());
     }
 }


### PR DESCRIPTION
We're using a different key/cert naming scheme in our deployments