### PR TITLE
Fix access token timestamps, add issuer

### DIFF
--- a/lib/Controller/Traits/AuthenticatedGetClientFromRequestTrait.php
+++ b/lib/Controller/Traits/AuthenticatedGetClientFromRequestTrait.php
@@ -23,7 +23,6 @@ use SimpleSAML\Module\oidc\Services\AuthContextService;
 
 trait AuthenticatedGetClientFromRequestTrait
 {
-
     /**
      * @var ClientRepository
      */

--- a/lib/Entity/ClientEntity.php
+++ b/lib/Entity/ClientEntity.php
@@ -99,7 +99,7 @@ class ClientEntity implements ClientEntityInterface
         $client->isEnabled = (bool) $state['is_enabled'];
         $client->isConfidential = (bool) ($state['is_confidential'] ?? false);
         $client->owner = $state['owner'] ?? null;
-        $client->postLogoutRedirectUri = json_decode($state['post_logout_redirect_uri']??"[]",true);
+        $client->postLogoutRedirectUri = json_decode($state['post_logout_redirect_uri'] ?? "[]", true);
         $client->backChannelLogoutUri = $state['backchannel_logout_uri'] ?? null;
 
         return $client;

--- a/lib/Server/Grants/Traits/IssueAccessTokenTrait.php
+++ b/lib/Server/Grants/Traits/IssueAccessTokenTrait.php
@@ -22,7 +22,6 @@ use SimpleSAML\Module\oidc\Repositories\Interfaces\AccessTokenRepositoryInterfac
  */
 trait IssueAccessTokenTrait
 {
-
     /**
      * @var AccessTokenRepositoryInterface
      */

--- a/spec/Factories/ClaimTranslatorExtractorFactorySpec.php
+++ b/spec/Factories/ClaimTranslatorExtractorFactorySpec.php
@@ -8,7 +8,6 @@ use SimpleSAML\Module\oidc\Services\ConfigurationService;
 
 class ClaimTranslatorExtractorFactorySpec extends ObjectBehavior
 {
-
     public function it_sets_private_scope_prefixes_and_types(ConfigurationService $configurationService)
     {
         $configurationService->getOpenIDConnectConfiguration()->willReturn(

--- a/tests/Entity/AccessTokenEntityTest.php
+++ b/tests/Entity/AccessTokenEntityTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SimpleSAML\Test\Module\oidc\Entity;
+
+use PHPUnit\Framework\MockObject\Stub;
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\oidc\Entity\AccessTokenEntity;
+use SimpleSAML\Module\oidc\Entity\ClientEntity;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Module\oidc\Entity\ScopeEntity;
+
+/**
+ * @covers \SimpleSAML\Module\oidc\Entity\AccessTokenEntity
+ *
+ * @backupGlobals enabled
+ */
+class AccessTokenEntityTest extends TestCase
+{
+    protected array $state;
+
+    protected string $id = '123';
+    protected array $scopes;
+    protected string $expiresAt;
+    protected string $userId = 'user123';
+    protected bool $isRevoked = false;
+    protected string $authCodeId = 'authCode123';
+    protected array $requestedClaims = ['key' => 'value'];
+    protected string $clientId = 'client123';
+
+
+    /**
+     * @var ClientEntity
+     */
+    protected ClientEntity $clientEntityStub;
+
+    /**
+     * @var ScopeEntity
+     */
+    protected ScopeEntity $scopeEntityOpenId;
+
+    /**
+     * @var ScopeEntity
+     */
+    protected ScopeEntity $scopeEntityProfile;
+
+    public static function setUpBeforeClass(): void
+    {
+        // To make lib/SimpleSAML/Utils/HTTP::getSelfURL() work...
+        global $_SERVER;
+        $_SERVER['REQUEST_URI'] = '';
+    }
+
+    protected function setUp(): void
+    {
+        // Plant certdir config for JsonWebTokenBuilderService (since we don't inject it)
+        $config = [
+            'certdir' => dirname(__DIR__, 2) . '/docker/ssp/',
+        ];
+        Configuration::loadFromArray($config, '', 'simplesaml');
+
+        $this->clientEntityStub = $this->createStub(ClientEntity::class);
+        $this->clientEntityStub->method('getIdentifier')->willReturn($this->clientId);
+
+        $this->scopeEntityOpenId = $this->createStub(ScopeEntity::class);
+        $this->scopeEntityOpenId->method('getIdentifier')->willReturn('openid');
+        $this->scopeEntityOpenId->method('jsonSerialize')->willReturn('openid');
+        $this->scopeEntityProfile = $this->createStub(ScopeEntity::class);
+        $this->scopeEntityProfile->method('getIdentifier')->willReturn('profile');
+        $this->scopeEntityProfile->method('jsonSerialize')->willReturn('profile');
+
+        $this->scopes = [$this->scopeEntityOpenId, $this->scopeEntityProfile,];
+
+        $this->expiresAt = date('Y-m-d H:i:s', strtotime('+10 minutes'));
+
+        $this->state = [
+            'id' => $this->id,
+            'scopes' => json_encode($this->scopes),
+            'expires_at' => $this->expiresAt,
+            'user_id' => $this->userId,
+            'client' => $this->clientEntityStub,
+            'is_revoked' => $this->isRevoked,
+            'auth_code_id' => $this->authCodeId,
+            'requested_claims' => json_encode($this->requestedClaims)
+        ];
+    }
+
+    public function testCanCreateInstanceFromState(): void
+    {
+        $this->assertInstanceOf(AccessTokenEntity::class, AccessTokenEntity::fromState($this->state));
+    }
+
+    public function testCanCreateInstanceFromData(): void
+    {
+        $this->assertInstanceOf(
+            AccessTokenEntity::class,
+            AccessTokenEntity::fromData(
+                $this->clientEntityStub,
+                $this->scopes,
+                $this->userId,
+                $this->authCodeId,
+                $this->requestedClaims
+            )
+        );
+    }
+
+    public function testHasProperState(): void
+    {
+        $accessTokenEntity = AccessTokenEntity::fromState($this->state);
+        $accessTokenEntityState = $accessTokenEntity->getState();
+
+        $this->assertSame($this->id, $accessTokenEntityState['id']);
+        $this->assertSame(json_encode($this->scopes), $accessTokenEntityState['scopes']);
+
+        $this->assertSame($this->requestedClaims, $accessTokenEntity->getRequestedClaims());
+    }
+
+    public function testHasImmutableStringRepresentation(): void
+    {
+        $accessTokenEntity = AccessTokenEntity::fromState($this->state);
+
+        $this->assertNull($accessTokenEntity->toString());
+
+        $stringRepresentation = (string) $accessTokenEntity;
+
+        $this->assertIsString($accessTokenEntity->toString());
+
+        $this->assertSame($stringRepresentation, $accessTokenEntity->toString());
+    }
+}

--- a/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
+++ b/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
@@ -19,7 +19,6 @@ use Throwable;
  */
 class RequestedClaimsRuleTest extends TestCase
 {
-
     protected ResultBag $resultBag;
     protected $clientStub;
     protected $request;


### PR DESCRIPTION
This is to change in how access token string representation is generated. Up to now, private method \League\OAuth2\Server\Entities\Traits\AccessTokenTrait::convertToJWT() was used.

This PR suggests that we switch to our own \SimpleSAML\Module\oidc\Services\JsonWebTokenBuilderService to generate access token, which already properly formats token timestamps and also adds issuer and key id for example (and enables us to modify any other claim on the JWT as we please).

Since \SimpleSAML\Module\oidc\Entity\AccessTokenEntity has static methods which serve as instantiation points (fromState(), fromData()) which return new self(), JsonWebTokenBuilderService is not injected through its __constructor().

Fixes #170 
Fixes #156