### PR TITLE
Set restart url for authorize commands

### DIFF
--- a/lib/Services/AuthenticationService.php
+++ b/lib/Services/AuthenticationService.php
@@ -17,6 +17,7 @@ namespace SimpleSAML\Module\oidc\Services;
 use Exception;
 use Psr\Http\Message\ServerRequestInterface;
 use SimpleSAML\Auth\Simple;
+use SimpleSAML\Auth\State;
 use SimpleSAML\Error;
 use SimpleSAML\Module\oidc\ClaimTranslatorExtractor;
 use SimpleSAML\Module\oidc\Controller\LogoutController;
@@ -163,6 +164,8 @@ class AuthenticationService
         // Source and destination entity IDs, useful for eg. F-ticks logging...
         $state['Source'] = ['entityid' => $state['Oidc']['OpenIdProviderMetadata']['issuer']];
         $state['Destination'] = ['entityid' => $state['Oidc']['RelyingPartyMetadata']['id']];
+
+        $state[State::RESTART] = $request->getUri()->__toString();
 
         return $state;
     }

--- a/spec/Services/AuthenticationServiceSpec.php
+++ b/spec/Services/AuthenticationServiceSpec.php
@@ -15,6 +15,7 @@
 namespace spec\SimpleSAML\Module\oidc\Services;
 
 use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Uri;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SimpleSAML\Auth\Simple;
@@ -56,6 +57,10 @@ class AuthenticationServiceSpec extends ObjectBehavior
         ],
     ];
 
+    public static $uri = 'https://some-server/authorize.php?abc=efg';
+
+
+
     /**
      * @param ServerRequest $request
      * @param ClientEntity $clientEntity
@@ -81,6 +86,7 @@ class AuthenticationServiceSpec extends ObjectBehavior
         ClaimTranslatorExtractor $claimTranslatorExtractor
     ): void {
         $request->getQueryParams()->willReturn(self::AUTHZ_REQUEST_PARAMS);
+        $request->getUri()->willReturn(new Uri(self::$uri));
         $clientEntity->getAuthSourceId()->willReturn(self::AUTH_SOURCE);
         $clientEntity->toArray()->willReturn(self::CLIENT_ENTITY);
         $clientRepository->findById(self::CLIENT_ENTITY['id'])->willReturn($clientEntity);


### PR DESCRIPTION
Sometimes authproc filters need to restart the login process. Changes sets a restart url (which is something the SAML Idp side does).