### PR TITLE
Logout tokens should have typ header with value 'logout+jwt'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "simplesamlphp/composer-module-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/lib/Services/LogoutTokenBuilder.php
+++ b/lib/Services/LogoutTokenBuilder.php
@@ -23,6 +23,7 @@ class LogoutTokenBuilder
     {
         $logoutTokenBuilder = $this->jsonWebTokenBuilderService
             ->getDefaultJwtTokenBuilder()
+            ->withHeader('typ', 'logout+jwt')
             ->permittedFor($relyingPartyAssociation->getClientId())
             ->relatedTo($relyingPartyAssociation->getUserId())
             ->withClaim('events', ['http://schemas.openid.net/event/backchannel-logout' => new stdClass()])

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
     <!-- Ignore deprecated classes -->
     <ignoreFiles>
        <directory name="www/assets" />
+       <file name="vendor/bin/psalm" />
     </ignoreFiles>
   </projectFiles>
 
@@ -45,7 +46,7 @@
     <!-- Ignore UnresolvableInclude on CLI-scripts -->
     <UnresolvableInclude>
         <errorLevel type="suppress">
-            <file name="tests/bootstrap.php" />
+          <file name="tests/bootstrap.php" />
         </errorLevel>
     </UnresolvableInclude>
   </issueHandlers>

--- a/tests/Services/LogoutTokenBuilderTest.php
+++ b/tests/Services/LogoutTokenBuilderTest.php
@@ -32,6 +32,7 @@ class LogoutTokenBuilderTest extends TestCase
     private static string $userId = 'user123';
     private static string $sessionId = 'session123';
     private static string $backChannelLogoutUri = 'https//some-host.org/logout';
+    private static string $logoutTokenType = 'logout+jwt';
     /**
      * @var mixed
      */
@@ -106,5 +107,8 @@ class LogoutTokenBuilderTest extends TestCase
                 )
             )
         );
+
+        $this->assertTrue($parsedToken->headers()->has('typ'));
+        $this->assertSame($parsedToken->headers()->get('typ'), self::$logoutTokenType);
     }
 }


### PR DESCRIPTION
OpenID backchannel logout spec recommends that logout tokens be explicitly typed:
> It is RECOMMENDED that Logout Tokens be explicitly typed. This is accomplished by including a typ (type) Header Parameter with a value of logout+jwt in the Logout Token. See [Section 4.1](https://openid.net/specs/openid-connect-backchannel-1_0.html#CrossJWT) for a discussion of the security and interoperability considerations of using explicit typing.

([source](https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken))

The [nimbus library](https://connect2id.com/products/nimbus-oauth-openid-connect-sdk) requires that typed logout tokens have type `logout+jwt`: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/ef594b7477dd46a4e64c61ee6b6e335e38b4b29f/src/main/java/com/nimbusds/openid/connect/sdk/validators/LogoutTokenValidator.java#lines-340

By default the tokens are typed with type `JWT`: https://github.com/lcobucci/jwt/blob/058b61b376339208622b6dc9d38b70a122338c20/src/Token/Builder.php#L21