### PR TITLE
Ignore unrecognized scopes (3.1.2.1 of spec)

### DIFF
--- a/lib/Utils/Checker/Rules/ScopeRule.php
+++ b/lib/Utils/Checker/Rules/ScopeRule.php
@@ -53,7 +53,8 @@ class ScopeRule extends AbstractRule
             $scope = $this->scopeRepository->getScopeEntityByIdentifier($scopeItem);
 
             if ($scope instanceof ScopeEntityInterface === false) {
-                throw OidcServerException::invalidScope($scopeItem, $redirectUri, $state);
+                $loggerService->info("Ignoring invalid scope '$scopeItem'");
+                continue;
             }
 
             $validScopes[] = $scope;

--- a/tests/Utils/Checker/Rules/ScopeRuleTest.php
+++ b/tests/Utils/Checker/Rules/ScopeRuleTest.php
@@ -126,8 +126,8 @@ class ScopeRuleTest extends TestCase
                 ]
             );
 
-  $result = (new ScopeRule($this->scopeRepositoryStub))
-      ->checkRule($this->requestStub, $resultBag, $this->loggerServiceStub, $this->data);
+        $result = (new ScopeRule($this->scopeRepositoryStub))
+        ->checkRule($this->requestStub, $resultBag, $this->loggerServiceStub, $this->data);
         $this->assertInstanceOf(ResultInterface::class, $result);
         $this->assertIsArray($result->getValue());
         $this->assertSame($this->scopeEntities['openid'], $result->getValue()[0]);


### PR DESCRIPTION
"Scope values used that are not understood by an implementation SHOULD be ignored" (per [spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest))

Previously we were returning an error.