### PR TITLE
Add Access-Control-Allow-Origin header to responses, if not already present

### DIFF
--- a/lib/Services/RoutingService.php
+++ b/lib/Services/RoutingService.php
@@ -81,12 +81,23 @@ class RoutingService
                 $response->data['messages'] = $container->get(SessionMessagesService::class)->getMessages();
             }
 
+            // If not already handled, allow CORS (for JS clients).
+            if (!$response->headers->has('Access-Control-Allow-Origin')) {
+                $response->headers->set('Access-Control-Allow-Origin', '*');
+            }
+
+
             $response->send();
 
             return;
         }
 
         if ($response instanceof ResponseInterface) {
+            // If not already handled, allow CORS (for JS clients).
+            if (!$response->hasHeader('Access-Control-Allow-Origin')) {
+                $response = $response->withHeader('Access-Control-Allow-Origin', '*');
+            }
+
             $emitter = new SapiEmitter();
 
             $emitter->emit($response);


### PR DESCRIPTION
Adding Access-Control-Allow-Origin header with value '*' will enable JS clients to get data from authn endpoints in cross-origin scenarios. This is in addition to already implemented CORS handling for 'userinfo' endpoint, which only allows registers origins for browser preflight CORS requests.

Fixes #189 