### PR TITLE
Introduce installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The module comes with some default SQL migrations which set up needed tables in 
 open the _Federation_ tab from your _SimpleSAMLphp_ installation and select the option _OpenID Connect Installation_
 inside the _Tools_ section. Once there, all you need to do is press the _Install_ button and the schema will be created.
 
+Alternatively, in case of automatic / scripted deployments, you can run the 'install.php' script from the command line:
+
+    php modules/oidc/bin/install.php
+
 ### Relying Party (RP) Administration
 
 The module lets you manage (create, read, update and delete) approved RPs from the module user interface itself.

--- a/bin/install.php
+++ b/bin/install.php
@@ -1,0 +1,39 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Script which can be run to do the module installation which includes running database migrations.
+ */
+
+use SimpleSAML\Database;
+use SimpleSAML\Module\oidc\Services\DatabaseMigration;
+
+// This is the base directory of the SimpleSAMLphp installation
+$baseDir = dirname(__FILE__, 4);
+
+// Add library autoloader and configuration
+require_once $baseDir . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . '_autoload.php';
+
+echo 'Starting with module installation.' . PHP_EOL;
+
+try {
+    $database = Database::getInstance();
+    $databaseMigration = new DatabaseMigration($database);
+
+    if ($databaseMigration->isUpdated()) {
+        echo 'Database is up to date, skipping.' . PHP_EOL;
+        return 0;
+    }
+
+    echo 'Running database migrations.' . PHP_EOL;
+
+    $databaseMigration->migrate();
+
+    echo 'Done running migrations.';
+    return 0;
+} catch (Throwable $exception) {
+    echo 'There was an error while trying run database migrations: ' . $exception->getMessage();
+    return 1;
+}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         },
         "sort-packages": true,
         "allow-plugins": {
-            "simplesamlphp/composer-module-installer": true
+            "simplesamlphp/composer-module-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "cache-dir": "build/composer"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -44,6 +44,9 @@
     <UnusedClass errorLevel="suppress" />
     <PossiblyUnusedMethod errorLevel="suppress" />
     <PossiblyUnusedReturnValue errorLevel="suppress" />
+
+    <!-- Ignore RiskyTruthyFalsyComparison -->
+    <RiskyTruthyFalsyComparison errorLevel="suppress" />
   </issueHandlers>
 </psalm>
 

--- a/src/Forms/ClientForm.php
+++ b/src/Forms/ClientForm.php
@@ -17,12 +17,16 @@ declare(strict_types=1);
 namespace SimpleSAML\Module\oidc\Forms;
 
 use Exception;
+use Nette\Forms\Container;
 use Nette\Forms\Form;
 use SimpleSAML\Auth\Source;
 use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Forms\Controls\CsrfProtection;
 use Traversable;
 
+/**
+ * @psalm-suppress PropertyNotSetInConstructor Raised for $httpRequest which is marked as internal, so won't handle.
+ */
 class ClientForm extends Form
 {
     protected const TYPE_ARRAY = 'array';
@@ -123,7 +127,7 @@ class ClientForm extends Form
         }
     }
 
-    public function getValues($returnType = null, ?array $controls = null): array
+    public function getValues(string|object|bool|null $returnType = null, ?array $controls = null): array
     {
         /** @var array $values */
         $values = parent::getValues(self::TYPE_ARRAY);
@@ -157,7 +161,7 @@ class ClientForm extends Form
     /**
      * @throws Exception
      */
-    public function setDefaults($data, bool $erase = false): ClientForm
+    public function setDefaults(object|array $data, bool $erase = false): static
     {
         if (! is_array($data)) {
             if ($data instanceof Traversable) {
@@ -187,7 +191,9 @@ class ClientForm extends Form
         $scopes = is_array($data['scopes']) ? $data['scopes'] : [];
         $data['scopes'] = array_intersect($scopes, array_keys($this->getScopes()));
 
-        return parent::setDefaults($data, $erase);
+        parent::setDefaults($data, $erase);
+
+        return $this;
     }
 
     /**
@@ -203,7 +209,7 @@ class ClientForm extends Form
         $this->onValidate[] = $this->validateBackChannelLogoutUri(...);
 
         $this->setMethod('POST');
-        $this->addComponent(new CsrfProtection('{oidc:client:csrf_error}'), Form::PROTECTOR_ID);
+        $this->addComponent(new CsrfProtection('{oidc:client:csrf_error}'), Form::ProtectorId);
 
         $this->addText('name', '{oidc:client:name}')
             ->setMaxLength(255)

--- a/src/Forms/Controls/CsrfProtection.php
+++ b/src/Forms/Controls/CsrfProtection.php
@@ -21,6 +21,7 @@ use Nette\Forms\Controls\CsrfProtection as BaseCsrfProtection;
 use Nette\InvalidStateException;
 use Nette\Utils\Random;
 use SimpleSAML\Session;
+use Stringable;
 
 class CsrfProtection extends BaseCsrfProtection
 {
@@ -32,7 +33,7 @@ class CsrfProtection extends BaseCsrfProtection
     /**
      * @throws Exception
      */
-    public function __construct(object|string $errorMessage)
+    public function __construct(string|Stringable|null $errorMessage)
     {
         // Instead of calling CsrfProtection parent class constructor, go to it's parent (HiddenField), and call
         // its constructor. This is to avoid setting a Nette session in CsrfProtection parent, and use the SSP one.

--- a/src/Utils/ClaimTranslatorExtractor.php
+++ b/src/Utils/ClaimTranslatorExtractor.php
@@ -197,7 +197,7 @@ class ClaimTranslatorExtractor
     {
         $scope = $claimSet->getScope();
 
-        if (in_array($scope, $this->protectedClaims) && !empty($this->claimSets[$scope])) {
+        if (in_array($scope, $this->protectedClaims) && isset($this->claimSets[$scope])) {
             throw OidcServerException::serverError(
                 sprintf("%s is a protected scope and is pre-defined by the OpenID Connect specification.", $scope)
             );


### PR DESCRIPTION
In case of automatic / scripted deployments, currently there is no way to run the database migrations other than from administration users interface in SimpleSAMLphp.

This PR introduces a separate installation PHP script which will utilize existing database migration class to run the migrations. This script can than be run from the command line.