### PR TITLE
Enable caching capabilities on UserRepository

### DIFF
--- a/config-templates/module_oidc.php
+++ b/config-templates/module_oidc.php
@@ -288,6 +288,13 @@ $config = [
     //    60 * 60 * 6, // Default lifetime in seconds (used when particular cache item doesn't define its own lifetime)
     //],
 
+    // Cache duration for user entities (authenticated users data). If not set, cache duration will be the same as
+    // session duration. This is used to avoid fetching user data from database on every authentication event.
+    // This is only relevant if protocol cache adapter is set up. For duration format info, check
+    // https://www.php.net/manual/en/dateinterval.construct.php.
+//    ModuleConfig::OPTION_PROTOCOL_USER_ENTITY_CACHE_DURATION => 'PT1H', // 1 hour
+    ModuleConfig::OPTION_PROTOCOL_USER_ENTITY_CACHE_DURATION => null, // fallback to session duration
+
     /**
      * Cron related options.
      */

--- a/docker/ssp/module_oidc.php
+++ b/docker/ssp/module_oidc.php
@@ -115,4 +115,9 @@ $config = [
     ModuleConfig::OPTION_AUTH_FORCED_ACR_VALUE_FOR_COOKIE_AUTHENTICATION => null,
 
     ModuleConfig::OPTION_CRON_TAG => 'hourly',
+
+    ModuleConfig::OPTION_PROTOCOL_CACHE_ADAPTER => \Symfony\Component\Cache\Adapter\FilesystemAdapter::class,
+    ModuleConfig::OPTION_PROTOCOL_CACHE_ADAPTER_ARGUMENTS => [
+        // Use defaults
+    ],
 ];

--- a/routing/services/services.yml
+++ b/routing/services/services.yml
@@ -116,3 +116,7 @@ services:
     factory: [ '@SimpleSAML\Module\oidc\Factories\FederationFactory', 'build' ]
   SimpleSAML\OpenID\Jwks:
     factory: [ '@SimpleSAML\Module\oidc\Factories\JwksFactory', 'build' ]
+
+  # SSP
+  SimpleSAML\Database:
+    factory: [ 'SimpleSAML\Database', 'getInstance' ]

--- a/src/Controller/Federation/Test.php
+++ b/src/Controller/Federation/Test.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\oidc\Controller\Federation;
 
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Codebooks\RegistrationTypeEnum;
 use SimpleSAML\Module\oidc\Factories\CoreFactory;
 use SimpleSAML\Module\oidc\Factories\Entities\ClientEntityFactory;
@@ -33,6 +34,7 @@ class Test
         protected ?FederationCache $federationCache,
         protected LoggerService $loggerService,
         protected Jwks $jwks,
+        protected Database $database,
         protected ClientEntityFactory $clientEntityFactory,
         protected CoreFactory $coreFactory,
         protected \DateInterval $maxCacheDuration = new \DateInterval('PT30S'),

--- a/src/ModuleConfig.php
+++ b/src/ModuleConfig.php
@@ -80,6 +80,7 @@ class ModuleConfig
     final public const OPTION_FEDERATION_ENTITY_STATEMENT_CACHE_DURATION = 'federation_entity_statement_cache_duration';
     final public const OPTION_PROTOCOL_CACHE_ADAPTER = 'protocol_cache_adapter';
     final public const OPTION_PROTOCOL_CACHE_ADAPTER_ARGUMENTS = 'protocol_cache_adapter_arguments';
+    final public const OPTION_PROTOCOL_USER_ENTITY_CACHE_DURATION = 'protocol_user_entity_cache_duration';
 
     protected static array $standardScopes = [
         ScopesEnum::OpenId->value => [
@@ -629,5 +630,21 @@ class ModuleConfig
     public function getProtocolCacheAdapterArguments(): array
     {
         return $this->config()->getOptionalArray(self::OPTION_PROTOCOL_CACHE_ADAPTER_ARGUMENTS, []);
+    }
+
+    /**
+     * Get cache duration for user entities (user data). If not set in configuration, it will fall back to SSP session
+     * duration.
+     *
+     * @throws \Exception
+     */
+    public function getUserEntityCacheDuration(): DateInterval
+    {
+        return new DateInterval(
+            $this->config()->getOptionalString(
+                self::OPTION_PROTOCOL_USER_ENTITY_CACHE_DURATION,
+                null,
+            ) ?? "PT{$this->sspConfig()->getInteger('session.duration')}S",
+        );
     }
 }

--- a/src/ModuleConfig.php
+++ b/src/ModuleConfig.php
@@ -638,7 +638,7 @@ class ModuleConfig
      *
      * @throws \Exception
      */
-    public function getUserEntityCacheDuration(): DateInterval
+    public function getProtocolUserEntityCacheDuration(): DateInterval
     {
         return new DateInterval(
             $this->config()->getOptionalString(

--- a/src/Repositories/AbstractDatabaseRepository.php
+++ b/src/Repositories/AbstractDatabaseRepository.php
@@ -15,24 +15,21 @@ declare(strict_types=1);
  */
 namespace SimpleSAML\Module\oidc\Repositories;
 
-use SimpleSAML\Configuration;
 use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\ModuleConfig;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 abstract class AbstractDatabaseRepository
 {
-    protected Configuration $config;
-
-    protected Database $database;
-
     /**
      * ClientRepository constructor.
      * @throws \Exception
      */
-    public function __construct(protected ModuleConfig $moduleConfig)
-    {
-        $this->config = $this->moduleConfig->config();
-        $this->database = Database::getInstance();
+    public function __construct(
+        protected readonly ModuleConfig $moduleConfig,
+        protected readonly Database $database,
+        protected readonly ?ProtocolCache $protocolCache,
+    ) {
     }
 
     abstract public function getTableName(): ?string;

--- a/src/Repositories/AccessTokenRepository.php
+++ b/src/Repositories/AccessTokenRepository.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface as OAuth2AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface as OAuth2ClientEntityInterface;
 use RuntimeException;
+use SimpleSAML\Database;
 use SimpleSAML\Error\Error;
 use SimpleSAML\Module\oidc\Codebooks\DateFormatsEnum;
 use SimpleSAML\Module\oidc\Entities\AccessTokenEntity;
@@ -30,6 +31,7 @@ use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\Interfaces\AccessTokenRepositoryInterface;
 use SimpleSAML\Module\oidc\Repositories\Traits\RevokeTokenByAuthCodeIdTrait;
 use SimpleSAML\Module\oidc\Server\Exceptions\OidcServerException;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 class AccessTokenRepository extends AbstractDatabaseRepository implements AccessTokenRepositoryInterface
 {
@@ -39,11 +41,13 @@ class AccessTokenRepository extends AbstractDatabaseRepository implements Access
 
     public function __construct(
         ModuleConfig $moduleConfig,
+        Database $database,
+        ?ProtocolCache $protocolCache,
         protected readonly ClientRepository $clientRepository,
         protected readonly AccessTokenEntityFactory $accessTokenEntityFactory,
         protected readonly Helpers $helpers,
     ) {
-        parent::__construct($moduleConfig);
+        parent::__construct($moduleConfig, $database, $protocolCache);
     }
 
     public function getTableName(): string

--- a/src/Repositories/AuthCodeRepository.php
+++ b/src/Repositories/AuthCodeRepository.php
@@ -18,6 +18,7 @@ namespace SimpleSAML\Module\oidc\Repositories;
 
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface as OAuth2AuthCodeEntityInterface;
 use RuntimeException;
+use SimpleSAML\Database;
 use SimpleSAML\Error\Error;
 use SimpleSAML\Module\oidc\Codebooks\DateFormatsEnum;
 use SimpleSAML\Module\oidc\Entities\AuthCodeEntity;
@@ -26,16 +27,19 @@ use SimpleSAML\Module\oidc\Factories\Entities\AuthCodeEntityFactory;
 use SimpleSAML\Module\oidc\Helpers;
 use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\Interfaces\AuthCodeRepositoryInterface;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 class AuthCodeRepository extends AbstractDatabaseRepository implements AuthCodeRepositoryInterface
 {
     public function __construct(
         ModuleConfig $moduleConfig,
+        Database $database,
+        ?ProtocolCache $protocolCache,
         protected readonly ClientRepository $clientRepository,
         protected readonly AuthCodeEntityFactory $authCodeEntityFactory,
         protected readonly Helpers $helpers,
     ) {
-        parent::__construct($moduleConfig);
+        parent::__construct($moduleConfig, $database, $protocolCache);
     }
 
     final public const TABLE_NAME = 'oidc_auth_code';

--- a/src/Repositories/ClientRepository.php
+++ b/src/Repositories/ClientRepository.php
@@ -17,18 +17,22 @@ namespace SimpleSAML\Module\oidc\Repositories;
 
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use PDO;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Entities\ClientEntity;
 use SimpleSAML\Module\oidc\Entities\Interfaces\ClientEntityInterface;
 use SimpleSAML\Module\oidc\Factories\Entities\ClientEntityFactory;
 use SimpleSAML\Module\oidc\ModuleConfig;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 class ClientRepository extends AbstractDatabaseRepository implements ClientRepositoryInterface
 {
     public function __construct(
         ModuleConfig $moduleConfig,
+        Database $database,
+        ?ProtocolCache $protocolCache,
         protected readonly ClientEntityFactory $clientEntityFactory,
     ) {
-        parent::__construct($moduleConfig);
+        parent::__construct($moduleConfig, $database, $protocolCache);
     }
 
     final public const TABLE_NAME = 'oidc_client';
@@ -389,7 +393,7 @@ EOF
      */
     private function getItemsPerPage(): int
     {
-        return $this->config
+        return $this->moduleConfig->config()
             ->getOptionalIntegerRange(ModuleConfig::OPTION_ADMIN_UI_PAGINATION_ITEMS_PER_PAGE, 1, 100, 20);
     }
 

--- a/src/Repositories/RefreshTokenRepository.php
+++ b/src/Repositories/RefreshTokenRepository.php
@@ -19,6 +19,7 @@ namespace SimpleSAML\Module\oidc\Repositories;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface as OAuth2RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use RuntimeException;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Codebooks\DateFormatsEnum;
 use SimpleSAML\Module\oidc\Entities\Interfaces\RefreshTokenEntityInterface;
 use SimpleSAML\Module\oidc\Entities\RefreshTokenEntity;
@@ -27,6 +28,7 @@ use SimpleSAML\Module\oidc\Helpers;
 use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\Interfaces\RefreshTokenRepositoryInterface;
 use SimpleSAML\Module\oidc\Repositories\Traits\RevokeTokenByAuthCodeIdTrait;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 class RefreshTokenRepository extends AbstractDatabaseRepository implements RefreshTokenRepositoryInterface
 {
@@ -36,11 +38,13 @@ class RefreshTokenRepository extends AbstractDatabaseRepository implements Refre
 
     public function __construct(
         ModuleConfig $moduleConfig,
+        Database $database,
+        ?ProtocolCache $protocolCache,
         protected readonly AccessTokenRepository $accessTokenRepository,
         protected readonly RefreshTokenEntityFactory $refreshTokenEntityFactory,
         protected readonly Helpers $helpers,
     ) {
-        parent::__construct($moduleConfig);
+        parent::__construct($moduleConfig, $database, $protocolCache);
     }
 
     /**

--- a/src/Repositories/ScopeRepository.php
+++ b/src/Repositories/ScopeRepository.php
@@ -26,18 +26,12 @@ use SimpleSAML\Module\oidc\ModuleConfig;
 use function array_key_exists;
 use function in_array;
 
-class ScopeRepository extends AbstractDatabaseRepository implements ScopeRepositoryInterface
+class ScopeRepository implements ScopeRepositoryInterface
 {
     public function __construct(
-        ModuleConfig $moduleConfig,
+        protected readonly ModuleConfig $moduleConfig,
         protected readonly ScopeEntityFactory $scopeEntityFactory,
     ) {
-        parent::__construct($moduleConfig);
-    }
-
-    public function getTableName(): ?string
-    {
-        return null;
     }
 
     /**

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -85,7 +85,15 @@ class UserRepository extends AbstractDatabaseRepository implements UserRepositor
             return null;
         }
 
-        return $this->userEntityFactory->fromState($row);
+        $userEntity = $this->userEntityFactory->fromState($row);
+
+        $this->protocolCache?->set(
+            $userEntity->getState(),
+            $this->moduleConfig->getProtocolUserEntityCacheDuration(),
+            $this->getCacheKey($userEntity->getIdentifier()),
+        );
+
+        return $userEntity;
     }
 
     /**

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -21,11 +21,13 @@ use Exception;
 use League\OAuth2\Server\Entities\ClientEntityInterface as OAuth2ClientEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Entities\UserEntity;
 use SimpleSAML\Module\oidc\Factories\Entities\UserEntityFactory;
 use SimpleSAML\Module\oidc\Helpers;
 use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\Interfaces\IdentityProviderInterface;
+use SimpleSAML\Module\oidc\Utils\ProtocolCache;
 
 class UserRepository extends AbstractDatabaseRepository implements UserRepositoryInterface, IdentityProviderInterface
 {
@@ -33,10 +35,12 @@ class UserRepository extends AbstractDatabaseRepository implements UserRepositor
 
     public function __construct(
         ModuleConfig $moduleConfig,
+        Database $database,
+        ?ProtocolCache $protocolCache,
         protected readonly Helpers $helpers,
         protected readonly UserEntityFactory $userEntityFactory,
     ) {
-        parent::__construct($moduleConfig);
+        parent::__construct($moduleConfig, $database, $protocolCache);
     }
 
     public function getTableName(): string

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -114,7 +114,7 @@ class UserRepository extends AbstractDatabaseRepository implements UserRepositor
 
         $this->protocolCache?->set(
             $userEntity->getState(),
-            $this->moduleConfig->getUserEntityCacheDuration(),
+            $this->moduleConfig->getProtocolUserEntityCacheDuration(),
             $this->getCacheKey($userEntity->getIdentifier()),
         );
     }
@@ -147,7 +147,7 @@ class UserRepository extends AbstractDatabaseRepository implements UserRepositor
 
         $this->protocolCache?->set(
             $userEntity->getState(),
-            $this->moduleConfig->getUserEntityCacheDuration(),
+            $this->moduleConfig->getProtocolUserEntityCacheDuration(),
             $this->getCacheKey($userEntity->getIdentifier()),
         );
     }

--- a/src/Services/Container.php
+++ b/src/Services/Container.php
@@ -204,7 +204,15 @@ class Container implements ContainerInterface
         );
         $this->services[ClientEntityFactory::class] = $clientEntityFactory;
 
-        $clientRepository = new ClientRepository($moduleConfig, $clientEntityFactory);
+        $database = Database::getInstance();
+        $this->services[Database::class] = $database;
+
+        $clientRepository = new ClientRepository(
+            $moduleConfig,
+            $database,
+            $protocolCache,
+            $clientEntityFactory,
+        );
         $this->services[ClientRepository::class] = $clientRepository;
 
         $userEntityFactory = new UserEntityFactory($helpers);
@@ -212,6 +220,8 @@ class Container implements ContainerInterface
 
         $userRepository = new UserRepository(
             $moduleConfig,
+            $database,
+            $protocolCache,
             $helpers,
             $userEntityFactory,
         );
@@ -228,6 +238,8 @@ class Container implements ContainerInterface
 
         $authCodeRepository = new AuthCodeRepository(
             $moduleConfig,
+            $database,
+            $protocolCache,
             $clientRepository,
             $authCodeEntityFactory,
             $helpers,
@@ -252,6 +264,8 @@ class Container implements ContainerInterface
 
         $accessTokenRepository = new AccessTokenRepository(
             $moduleConfig,
+            $database,
+            $protocolCache,
             $clientRepository,
             $accessTokenEntityFactory,
             $helpers,
@@ -263,6 +277,8 @@ class Container implements ContainerInterface
 
         $refreshTokenRepository = new RefreshTokenRepository(
             $moduleConfig,
+            $database,
+            $protocolCache,
             $accessTokenRepository,
             $refreshTokenEntityFactory,
             $helpers,
@@ -272,11 +288,12 @@ class Container implements ContainerInterface
         $scopeRepository = new ScopeRepository($moduleConfig, $scopeEntityFactory);
         $this->services[ScopeRepository::class] = $scopeRepository;
 
-        $allowedOriginRepository = new AllowedOriginRepository($moduleConfig);
+        $allowedOriginRepository = new AllowedOriginRepository(
+            $moduleConfig,
+            $database,
+            $protocolCache,
+        );
         $this->services[AllowedOriginRepository::class] = $allowedOriginRepository;
-
-        $database = Database::getInstance();
-        $this->services[Database::class] = $database;
 
         $databaseMigration = new DatabaseMigration($database);
         $this->services[DatabaseMigration::class] = $databaseMigration;

--- a/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
+++ b/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
@@ -168,7 +168,7 @@ class RevokeTokenByAuthCodeIdTraitTest extends TestCase
             $moduleConfig,
             $database,
             null,
-            $clientEntityFactoryMock
+            $clientEntityFactoryMock,
         );
 
         $this->accessTokenRepository = new AccessTokenRepository(

--- a/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
+++ b/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
@@ -138,7 +138,7 @@ class RevokeTokenByAuthCodeIdTraitTest extends TestCase
 
         $moduleConfig = new ModuleConfig();
 
-        $this->mock = new class ($moduleConfig) extends AbstractDatabaseRepository {
+        $this->mock = new class ($moduleConfig, $database, null) extends AbstractDatabaseRepository {
             use RevokeTokenByAuthCodeIdTrait;
 
             public function getTableName(): ?string

--- a/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
+++ b/tests/integration/src/Repositories/Traits/RevokeTokenByAuthCodeIdTraitTest.php
@@ -162,10 +162,19 @@ class RevokeTokenByAuthCodeIdTraitTest extends TestCase
         $clientEntityFactoryMock = $this->createMock(ClientEntityFactory::class);
         $clientEntityFactoryMock->method('fromState')->willReturn($clientEntityMock);
 
-        $clientRepositoryMock = new ClientRepository($moduleConfig, $clientEntityFactoryMock);
+        $database = Database::getInstance();
+
+        $clientRepositoryMock = new ClientRepository(
+            $moduleConfig,
+            $database,
+            null,
+            $clientEntityFactoryMock
+        );
 
         $this->accessTokenRepository = new AccessTokenRepository(
             $moduleConfig,
+            $database,
+            null,
             $clientRepositoryMock,
             $this->accessTokenEntityFactory,
             new Helpers(),
@@ -180,6 +189,8 @@ class RevokeTokenByAuthCodeIdTraitTest extends TestCase
         $user = new UserEntity(self::USER_ID, $createUpdatedAt, $createUpdatedAt, []);
         $userRepositoryMock = new UserRepository(
             $moduleConfig,
+            $database,
+            null,
             $helpers,
             new UserEntityFactory($helpers),
         );

--- a/tests/unit/src/Repositories/AccessTokenRepositoryTest.php
+++ b/tests/unit/src/Repositories/AccessTokenRepositoryTest.php
@@ -20,6 +20,7 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Codebooks\DateFormatsEnum;
 use SimpleSAML\Module\oidc\Entities\AccessTokenEntity;
 use SimpleSAML\Module\oidc\Entities\Interfaces\ClientEntityInterface;
@@ -102,8 +103,12 @@ class AccessTokenRepositoryTest extends TestCase
         $this->dateTimeHelperMock = $this->createMock(Helpers\DateTime::class);
         $this->helpersMock->method('dateTime')->willReturn($this->dateTimeHelperMock);
 
+        $database = Database::getInstance();
+
         $this->repository = new AccessTokenRepository(
             $this->moduleConfigMock,
+            $database,
+            null,
             $this->clientRepositoryMock,
             $this->accessTokenEntityFactoryMock,
             $this->helpersMock,

--- a/tests/unit/src/Repositories/AllowedOriginRepositoryTest.php
+++ b/tests/unit/src/Repositories/AllowedOriginRepositoryTest.php
@@ -6,6 +6,7 @@ namespace SimpleSAML\Test\Module\oidc\unit\Repositories;
 
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Services\DatabaseMigration;
@@ -45,7 +46,12 @@ class AllowedOriginRepositoryTest extends TestCase
     protected function setUp(): void
     {
         $moduleConfigMock = $this->createMock(ModuleConfig::class);
-        $this->repository = new AllowedOriginRepository($moduleConfigMock);
+        $database = Database::getInstance();
+        $this->repository = new AllowedOriginRepository(
+            $moduleConfigMock,
+            $database,
+            null,
+        );
     }
 
     public function tearDown(): void

--- a/tests/unit/src/Repositories/AuthCodeRepositoryTest.php
+++ b/tests/unit/src/Repositories/AuthCodeRepositoryTest.php
@@ -21,6 +21,7 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Codebooks\DateFormatsEnum;
 use SimpleSAML\Module\oidc\Entities\AuthCodeEntity;
 use SimpleSAML\Module\oidc\Entities\ClientEntity;
@@ -84,8 +85,12 @@ class AuthCodeRepositoryTest extends TestCase
         $this->dateTimeHelperMock = $this->createMock(Helpers\DateTime::class);
         $this->helpersMock->method('dateTime')->willReturn($this->dateTimeHelperMock);
 
+        $database = Database::getInstance();
+
         $this->repository = new AuthCodeRepository(
             $this->createMock(ModuleConfig::class),
+            $database,
+            null,
             $this->clientRepositoryMock,
             $this->authCodeEntityFactoryMock,
             $this->helpersMock,

--- a/tests/unit/src/Repositories/ClientRepositoryTest.php
+++ b/tests/unit/src/Repositories/ClientRepositoryTest.php
@@ -18,6 +18,7 @@ namespace SimpleSAML\Test\Module\oidc\unit\Repositories;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Entities\ClientEntity;
 use SimpleSAML\Module\oidc\Entities\Interfaces\ClientEntityInterface;
 use SimpleSAML\Module\oidc\Factories\Entities\ClientEntityFactory;
@@ -58,8 +59,12 @@ class ClientRepositoryTest extends TestCase
         $this->clientEntityMock = $this->createMock(ClientEntityInterface::class);
         $this->clientEntityFactoryMock = $this->createMock(ClientEntityFactory::class);
 
+        $database = Database::getInstance();
+
         $this->repository = new ClientRepository(
             new ModuleConfig(),
+            $database,
+            null,
             $this->clientEntityFactoryMock,
         );
     }

--- a/tests/unit/src/Repositories/RefreshTokenRepositoryTest.php
+++ b/tests/unit/src/Repositories/RefreshTokenRepositoryTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Entities\AccessTokenEntity;
 use SimpleSAML\Module\oidc\Entities\RefreshTokenEntity;
 use SimpleSAML\Module\oidc\Factories\Entities\RefreshTokenEntityFactory;
@@ -76,8 +77,12 @@ class RefreshTokenRepositoryTest extends TestCase
 
         $this->refreshTokenEntityMock = $this->createMock(RefreshTokenEntity::class);
 
+        $database = Database::getInstance();
+
         $this->repository = new RefreshTokenRepository(
             new ModuleConfig(),
+            $database,
+            null,
             $this->accessTokenRepositoryMock,
             $this->refreshTokenEntityFactoryMock,
             new Helpers(),

--- a/tests/unit/src/Repositories/UserRepositoryTest.php
+++ b/tests/unit/src/Repositories/UserRepositoryTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use SimpleSAML\Configuration;
+use SimpleSAML\Database;
 use SimpleSAML\Module\oidc\Entities\UserEntity;
 use SimpleSAML\Module\oidc\Factories\Entities\UserEntityFactory;
 use SimpleSAML\Module\oidc\Helpers;
@@ -59,8 +60,12 @@ class UserRepositoryTest extends TestCase
         $this->userEntityFactoryMock = $this->createMock(UserEntityFactory::class);
         $this->userEntityMock = $this->createMock(UserEntity::class);
 
+        $database = Database::getInstance();
+
         self::$repository = new UserRepository(
             $moduleConfig,
+            $database,
+            null,
             $this->helpersStub,
             $this->userEntityFactoryMock,
         );

--- a/tests/unit/src/Repositories/UserRepositoryTest.php
+++ b/tests/unit/src/Repositories/UserRepositoryTest.php
@@ -29,7 +29,6 @@ use SimpleSAML\Module\oidc\ModuleConfig;
 use SimpleSAML\Module\oidc\Repositories\UserRepository;
 use SimpleSAML\Module\oidc\Services\DatabaseMigration;
 use SimpleSAML\Module\oidc\Utils\ProtocolCache;
-use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
  * @covers \SimpleSAML\Module\oidc\Repositories\UserRepository
@@ -84,9 +83,8 @@ class UserRepositoryTest extends TestCase
         Database|MockObject $database = null,
         ProtocolCache|MockObject $protocolCache = null,
         Helpers|MockObject $helpers = null,
-        UserEntityFactory|MockObject $userEntityFactory = null
-    ): UserRepository
-    {
+        UserEntityFactory|MockObject $userEntityFactory = null,
+    ): UserRepository {
         $moduleConfig ??= $this->moduleConfigMock;
         $database ??= $this->database; // Let's use real database instance for tests by default.
         $protocolCache ??= null; // Let's not use cache for tests by default.
@@ -201,11 +199,19 @@ class UserRepositoryTest extends TestCase
             ->method('get')
             ->willReturn(null);
 
+        $this->protocolCacheMock->expects($this->once())
+            ->method('set')
+            ->with($this->userEntityState);
+
         $this->pdoStatementMock->method('fetchAll')->willReturn([$this->userEntityState]);
 
         $this->databaseMock->expects($this->once())
             ->method('read')
             ->willReturn($this->pdoStatementMock);
+
+        $this->userEntityMock->expects($this->once())
+            ->method('getState')
+            ->willReturn($this->userEntityState);
 
         $this->userEntityFactoryMock->expects($this->once())
             ->method('fromState')
@@ -293,7 +299,7 @@ class UserRepositoryTest extends TestCase
                 $this->stringContains('DELETE'),
                 $this->callback(function (array $params) {
                     return $params['id'] === 'uniqueid';
-                })
+                }),
             );
 
         $this->mock(


### PR DESCRIPTION
This PR introduces caching capabilities on UserRepository as a demonstration of proposed implementation. I plan to do similarly on other repositories as well (but it will be a bit more complicated). 

The intention is to enable implementor to configure 'Protocol Cache', which would then be used 'in front of' the regular database storage for protocol artifacts like tokens, and also for oidc clients and user data. Any Symfony cache adapter is supported. If the 'Protocol Cache' is not enabled or artifact is not cached, everything falls back to database. 

If the implementor chooses to enable this, and enables some 'memory-capable' adapter, like memcache or similar, this should significantly improve performance, especially in cases like sudden surge of users when the database-only-storage becomes a noticable bootleneck. 