### PR TITLE
Fix redirect_uri regex

### DIFF
--- a/src/Forms/ClientForm.php
+++ b/src/Forms/ClientForm.php
@@ -34,6 +34,8 @@ class ClientForm extends Form
 
     /**
      * RFC3986. AppendixB. Parsing a URI Reference with a Regular Expression.
+     * From v6.*, the regex was modified to allow URI without host, to support adding entries like
+     * `openid-credential-offer://`
      */
     final public const REGEX_URI = '/^[^:]+:\/\/?([^\s\/$.?#].[^\s]*)?$/';
 

--- a/src/Forms/ClientForm.php
+++ b/src/Forms/ClientForm.php
@@ -35,7 +35,7 @@ class ClientForm extends Form
     /**
      * RFC3986. AppendixB. Parsing a URI Reference with a Regular Expression.
      */
-    final public const REGEX_URI = '/^[^:]+:\/\/?[^\s\/$.?#].[^\s]*$/';
+    final public const REGEX_URI = '/^[^:]+:\/\/?([^\s\/$.?#].[^\s]*)?$/';
 
     /**
      * Must have http:// or https:// scheme, and at least one 'domain.top-level-domain' pair, or more subdomains.

--- a/tests/unit/src/Forms/ClientFormTest.php
+++ b/tests/unit/src/Forms/ClientFormTest.php
@@ -171,4 +171,36 @@ class ClientFormTest extends TestCase
 
         $this->assertNull($sut->getValues()['auth_source']);
     }
+
+    public static function redirectUriProvider(): array
+    {
+        return [
+            ['https', false],
+            ['https:', false],
+            ['example', false],
+            ['example.com', false],
+            ['example.com/?foo=bar', false],
+            ['www.example.com/?foo=bar', false],
+            ['https://example', true],
+            ['https://example.com', true],
+            ['https://example.com/', true],
+            ['https://example.com/foo', true],
+            ['https://example.com/foo?bar=1', true],
+
+            // To support OID4VCI
+            ['openid-credential-offer://', true],
+            ['foo://', true],
+            ['https://', true],
+        ];
+    }
+
+    #[DataProvider('redirectUriProvider')]
+    public function testCanValidateRedirectUri(string $url, bool $isValid): void
+    {
+        $sut = $this->sut();
+        $sut->setValues(['redirect_uri' => $url]);
+        $sut->validateRedirectUri($sut);
+
+        $this->assertEquals(!$isValid, $sut->hasErrors(), $url);
+    }
 }


### PR DESCRIPTION
Make hostname part of redirect_uri regex check optional. This should enable redirect_uri's like `openid-credential-offer://` used in OpenID for Verifiable Credential Issuance.