### PR TITLE
OIDF: move from `id` to `trust_mark_id` claim

### DIFF
--- a/src/Controllers/Federation/EntityStatementController.php
+++ b/src/Controllers/Federation/EntityStatementController.php
@@ -136,12 +136,12 @@ class EntityStatementController
                 if ($trustMarkEntity->getSubject() !== $this->moduleConfig->getIssuer()) {
                     throw OidcServerException::serverError(sprintf(
                         'Trust Mark %s is not intended for this entity.',
-                        $trustMarkEntity->getIdentifier(),
+                        $trustMarkEntity->getTrustMarkId(),
                     ));
                 }
 
                 return [
-                    ClaimsEnum::Id->value => $trustMarkEntity->getIdentifier(),
+                    ClaimsEnum::Id->value => $trustMarkEntity->getTrustMarkId(),
                     ClaimsEnum::TrustMark->value => $token,
                 ];
             }, $trustMarkTokens);


### PR DESCRIPTION
Updates regarding OpenID Federation draft 42. Other changes are implemented through underlying `openid` library.