### PR TITLE
Make sub claim value single value only

### DIFF
--- a/src/Utils/ClaimTranslatorExtractor.php
+++ b/src/Utils/ClaimTranslatorExtractor.php
@@ -126,6 +126,33 @@ class ClaimTranslatorExtractor
     ];
 
     /**
+     * As per https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+     */
+    final public const MANDATORY_SINGLE_VALUE_CLAIMS = [
+        'sub',
+        // TODO mivanci v7 Uncomment the rest of the claims, as this was a potential breaking change in v6.
+//        'name',
+//        'given_name',
+//        'family_name',
+//        'middle_name',
+//        'nickname',
+//        'preferred_username',
+//        'profile',
+//        'picture',
+//        'website',
+//        'email',
+//        'email_verified',
+//        'gender',
+//        'birthdate',
+//        'zoneinfo',
+//        'locale',
+//        'phone_number',
+//        'phone_number_verified',
+//        'address',
+//        'updated_at',
+    ];
+
+    /**
      * ClaimTranslatorExtractor constructor.
      *
      * @param \SimpleSAML\Module\oidc\Entities\Interfaces\ClaimSetEntityInterface[] $claimSets
@@ -248,7 +275,8 @@ class ClaimTranslatorExtractor
             foreach ($attributes as $samlMatch) {
                 if (array_key_exists($samlMatch, $samlAttributes)) {
                     /** @psalm-suppress MixedAssignment, MixedArgument */
-                    $values = in_array($claim, $this->allowedMultiValueClaims, true) ?
+                    $values =  (!in_array($claim, self::MANDATORY_SINGLE_VALUE_CLAIMS, true)) &&
+                    in_array($claim, $this->allowedMultiValueClaims, true) ?
                     $samlAttributes[$samlMatch] :
                     current($samlAttributes[$samlMatch]);
                     /** @psalm-suppress MixedAssignment */

--- a/tests/unit/src/Utils/ClaimTranslatorExtractorTest.php
+++ b/tests/unit/src/Utils/ClaimTranslatorExtractorTest.php
@@ -292,4 +292,98 @@ class ClaimTranslatorExtractorTest extends TestCase
         $translate = ['nickname' => []];
         $this->assertFalse(in_array('nickname', $this->mock([], $translate)->getSupportedClaims(), true));
     }
+
+    public function testCanReleaseMultiValueClaims(): void
+    {
+        $claimSet = new ClaimSetEntity(
+            'multiValueClaimsScope',
+            ['multiValueClaim'],
+        );
+
+        $translate = [
+            'multiValueClaim' => [
+                'multiValueAttribute',
+            ],
+        ];
+
+        $userAttributes = [
+            'multiValueAttribute' => ['1', '2', '3'],
+        ];
+
+
+        $claimTranslator = $this->mock([$claimSet], $translate, ['multiValueClaim']);
+
+        $releasedClaims = $claimTranslator->extract(
+            ['multiValueClaimsScope'],
+            $userAttributes,
+        );
+
+        $expectedClaims = [
+            'multiValueClaim' => ['1', '2', '3'],
+        ];
+
+        $this->assertSame($expectedClaims, $releasedClaims);
+    }
+
+    public function testWillReleaseSingleValueClaimsIfMultiValueNotAllowed(): void
+    {
+        $claimSet = new ClaimSetEntity(
+            'multiValueClaimsScope',
+            ['multiValueClaim'],
+        );
+
+
+        $translate = [
+            'multiValueClaim' => [
+                'multiValueAttribute',
+            ],
+        ];
+
+        $userAttributes = [
+            'multiValueAttribute' => ['1', '2', '3'],
+        ];
+
+        $claimTranslator = $this->mock([$claimSet], $translate, []);
+
+        $releasedClaims = $claimTranslator->extract(
+            ['multiValueClaimsScope'],
+            $userAttributes,
+        );
+
+        $expectedClaims = ['multiValueClaim' => '1'];
+
+        $this->assertSame($expectedClaims, $releasedClaims);
+    }
+
+    public function testWillReleaseSingleValueClaimsForMandatorySingleValueClaims(): void
+    {
+
+        // TODO mivanci v7 Test for mandatory single value claims in other scopes, as per
+        // \SimpleSAML\Module\oidc\Utils\ClaimTranslatorExtractor::MANDATORY_SINGLE_VALUE_CLAIMS
+        $claimSet = new ClaimSetEntity(
+            'customScopeWithSubClaim',
+            ['sub'],
+        );
+
+        $translate = [
+            'sub' => [
+                'subAttribute',
+            ],
+        ];
+
+        $userAttributes = [
+            'subAttribute' => ['1', '2', '3'],
+        ];
+
+        $claimTranslator = $this->mock([$claimSet], $translate, ['sub']);
+
+        $releasedClaims = $claimTranslator->extract(
+            ['openid'],
+            $userAttributes,
+        );
+
+        $expectedClaims = ['sub' => '1'];
+
+        $this->assertSame($expectedClaims, $releasedClaims);
+    }
 }


### PR DESCRIPTION
In custom scopes, one can also use standard claims. Custom scopes have an option to allow a claim to have multiple values. Standard claims have predefined format, as per https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims. 
OIDC module expects certain claims to have single value (for example, `sub` claim). Setting it to multi value brakes the app. This PR solves that. 

Note: this PR only solves the `sub` claim, while the other user claims will be resolved in v7 branch, since this can potentially be a breaking change (one can set standard claim as multi value in custom scope, and the OIDC module wouldn't mind, as it doesn't reference them in code).

Closes #308 

